### PR TITLE
Сбор и публикация метрики покрытия unit-тестами

### DIFF
--- a/.github/workflows/Smoke.yml
+++ b/.github/workflows/Smoke.yml
@@ -49,7 +49,11 @@ jobs:
       run: dotnet build --no-restore --configuration Debug --nologo -p:Version=${{ env.version }}
 
     - name: Test
-      run: dotnet test --no-build --configuration Debug --nologo
+      run: dotnet test --no-build --configuration Debug --nologo --collect:"XPlat code coverage"
+
+    - name: Upload coverage to Codecov
+      if: matrix.os == 'ubuntu-latest'
+      uses: codecov/codecov-action@v1
 
     - name: Pack
       run: |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Auditor
 
-[![Build status badge](https://github.com/DotNetRu/Auditor/actions/workflows/Smoke.yml/badge.svg)](https://github.com/DotNetRu/Auditor/actions/workflows/Smoke.yml) [![NuGet Version badge](https://img.shields.io/nuget/v/DotNetRu.Auditor?style=flat&label=NuGet&logo=NuGet)](https://www.nuget.org/packages/DotNetRu.Auditor/)
+[![Build status badge](https://github.com/DotNetRu/Auditor/actions/workflows/Smoke.yml/badge.svg)](https://github.com/DotNetRu/Auditor/actions/workflows/Smoke.yml) [![NuGet Version badge](https://img.shields.io/nuget/v/DotNetRu.Auditor?style=flat&label=NuGet&logo=NuGet)](https://www.nuget.org/packages/DotNetRu.Auditor/) [![Code coverage](https://codecov.io/gh/DotNetRu/Auditor/branch/master/graph/badge.svg)](https://codecov.io/gh/DotNetRu/Auditor)
 
 
 Auditor — это набор библиотек для работы с [Audit'ом](https://github.com/DotNetRu/Audit) — базой данных основных активностей сообществ DotNetRu. Этот репозиторий был создан с целью упростить использование Audit'а в .NET приложениях. Он предоставляет стоготипизированные классы для работы с данными на разных уровнях и позволяет не зависеть от особенностей реализации и структуры хранящихся данных.

--- a/test/IntegrationTests/IntegrationTests.csproj
+++ b/test/IntegrationTests/IntegrationTests.csproj
@@ -6,13 +6,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="1.3.0">
+    <PackageReference Include="coverlet.collector" Version="3.0.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/test/UnitTests/UnitTests.csproj
+++ b/test/UnitTests/UnitTests.csproj
@@ -6,13 +6,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="1.3.0">
+    <PackageReference Include="coverlet.collector" Version="3.0.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
Как обсуждалось в #19, добавил сборку покрытия тестами для проектов тестирования. Публикация результатов - на [codecov](https://app.codecov.io/gh/DotNetRu).
Появится, когда будет сборка для ветки `master`.
Что сделано:
 - обновил тестовые sdk
 - обновил пакеты сборщика метрик `coverlet.collector`
 - добавил сборку покрытия в шаге тестирования в pipeline `Smoke`
 - добавил шаг публикации покрытия в pipeline `Smoke`
 - добавил сборку покрытия в шаге тестирования в pipeline `Publish`
 - добавил шаг публикации покрытия в pipeline `Publish`
 - добавил badge от codecov в `README.md` (бейджик заработает, когда отработает `smoke.yaml` для ветки `master`)